### PR TITLE
Fix duel accept menu.

### DIFF
--- a/src/main/java/com/teozcommunity/teozfrank/duelme/menus/AcceptMenu.java
+++ b/src/main/java/com/teozcommunity/teozfrank/duelme/menus/AcceptMenu.java
@@ -59,7 +59,7 @@ public class AcceptMenu implements Listener {
      */
     public void openNormalDuelAccept(Player sender, Player target){
         senderName = sender.getName();
-        acceptMenu = Bukkit.getServer().createInventory(null, 9 , ChatColor.translateAlternateColorCodes('&', "&cDuel Request from " + sender.getName()));
+        acceptMenu = Bukkit.getServer().createInventory(null, 9 , ChatColor.translateAlternateColorCodes('&', "&cChallenged by " + sender.getName()));
         accept = Util.createMenuItem(DyeColor.GREEN, "Accept", "Click this item to accept a duel request.");
         ignore = Util.createMenuItem(DyeColor.RED, "Ignore", "Click this item to ignore this duel request.");
 


### PR DESCRIPTION
Players with long names will cause  openNormalDuelAccept() to fail with: "java.lang.IllegalArgumentException: Title cannot be longer than 32 characters"

Since player names are 16 characters or less, I edited the menu title to be only 16 characters long allowing for another 16 characters for names.